### PR TITLE
removed mtest dependency

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,5 +5,5 @@ MRuby::Gem::Specification.new('mruby-socket') do |spec|
   spec.cc.include_paths << "#{build.root}/src"
 
   spec.add_dependency('mruby-io')
-  spec.add_dependency('mruby-mtest')
+  # spec.add_dependency('mruby-mtest')
 end


### PR DESCRIPTION
the test framework should not be mandatory when building a production release.
