### PR TITLE
Add _WIN32_WINNT definition to Avoid Windows Compilation Errors

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -5,6 +5,8 @@
 */
 
 #ifdef _WIN32
+  #define _WIN32_WINNT 0x0501
+  
   #include <winsock2.h>
   #include <ws2tcpip.h>
   #include <windows.h>


### PR DESCRIPTION
the line #define _WIN32_WINNT 0x0501 will cause ws2tcpip.h to implement the missing functions freeaddrinfo, getaddrinfo and getnameinfo on windows