### PR TITLE
Fix type int to mrb_int

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -611,10 +611,10 @@ mrb_socket_connect(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_socket_listen(mrb_state *mrb, mrb_value klass)
 {
-  int backlog, s;
+  mrb_int backlog, s;
 
   mrb_get_args(mrb, "ii", &s, &backlog);
-  if (listen(s, backlog) == -1) {
+  if (listen((int)s, (int)backlog) == -1) {
     mrb_sys_fail(mrb, "listen");
   }
   return mrb_nil_value();


### PR DESCRIPTION
With mruby master, some tests are failing:

```
>>> Test host <<<                                                                                                                                      [80/8324]
mrbtest - Embeddable Ruby Test

........S.................................................................................................?.....................................................
................................................................................................................................................................
.........................................?.......................?.............................................................................................X
XXXXXXXXX.......................................................................................................................................................
............................................................??..................................................................................................
.......................................................................................................................?........................................
..................................................................................................................................................
Skip: Struct.new removes existing constant  redefining Struct with same name cause warnings
Skip: Kernel.caller, Kernel#caller  backtrace isn't available
Skip: File.expand_path (with ENV)  
MTest 1) Skipped:
test_assert_match(Test4MTest) MTest::Skip: assert_match is not defined, because Regexp is not impl.

RuntimeError: UNIXServer.new => listen (mrbgems: mruby-socket)
RuntimeError: UNIXServer#addr => listen (mrbgems: mruby-socket)
RuntimeError: UNIXServer#path => listen (mrbgems: mruby-socket)
RuntimeError: UNIXServer#listen => listen (mrbgems: mruby-socket)
RuntimeError: UNIXServer#sysaccept => listen (mrbgems: mruby-socket)
RuntimeError: UNIXSocket.new => listen (mrbgems: mruby-socket)
RuntimeError: UNIXSocket#addr => listen (mrbgems: mruby-socket)
RuntimeError: UNIXSocket#path => listen (mrbgems: mruby-socket)
RuntimeError: UNIXSocket#peeraddr => listen (mrbgems: mruby-socket)
RuntimeError: UNIXSocket#recvfrom => listen (mrbgems: mruby-socket)
Skip: GC in rescue  backtrace isn't available
Skip: Method call in rescue  backtrace isn't available
Skip: Module#prepend super in alias  super does not currently work in aliased methods
Total: 1099
   OK: 1089
   KO: 0
Crash: 10
 Time: 0.18 seconds
```

`Socket._listen` seems to be a point that got broken:

```console
$ strace ./mruby/bin/mruby -e 'Socket._listen 10, 5' 2>&1 | grep listen # or any number to 1st arg
listen(0, 5)                            = -1 ENOTSOCK (Socket operation on non-socket)
```

I looked into this phenomenon and found mruby's default int size was changed after: https://github.com/mruby/mruby/commit/f0f4a1088a270e339407a24ffe8be748f4764fc2
Implicit cast may cause some errors, so I want to fix.