### PR TITLE
Declare inet_ntop and inet_pton as static

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -44,7 +44,7 @@
 #endif
 
 #ifdef _WIN32
-const char *inet_ntop(int af, const void *src, char *dst, socklen_t cnt)
+static const char *inet_ntop(int af, const void *src, char *dst, socklen_t cnt)
 {
     if (af == AF_INET)
     {
@@ -69,7 +69,7 @@ const char *inet_ntop(int af, const void *src, char *dst, socklen_t cnt)
     return NULL;
 }
 
-int inet_pton(int af, const char *src, void *dst)
+static int inet_pton(int af, const char *src, void *dst)
 {
     struct addrinfo hints, *res, *ressave;
 


### PR DESCRIPTION
To avoid conflicts with multiple definitions of inet_ntop and inet_pton

```
C:/mingw-w64/x86_64-7.2.0-posix-seh-rt_v5-rev1/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/7.2.0/../../../../x86_64-w64-mingw32/lib/../lib/libWs2_32.a(dghfs00169.o):(.text+0x0): multiple definition of `inet_pton'
722C:/projects/iss/mruby/build/host/lib/libmruby.a(socket.o):C:/projects/iss/mruby/mrbgems/mruby-socket/src/socket.c:80: first defined here
```

if compiled with:

```c
# define _WIN32_WINNT _WIN32_WINNT_VISTA
```